### PR TITLE
Package name must be lowercase without blanks.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "Deepgram Chrome Extension",
+  "name": "deepgram-chrome-extension",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "Deepgram Chrome Extension",
+      "name": "deepgram-chrome-extension",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Deepgram Chrome Extension",
+  "name": "deepgram-chrome-extension",
   "version": "0.1.0",
   "description": "A chrome extension for audio transcription, powered by Deepgram",
   "license": "MIT",


### PR DESCRIPTION
NPM package names must be lowercase without blanks.

Fixes Error package.json: Name contains illegal characters #8 