### PR TITLE
Disable noImplicitAny rule and add SVG declaration

### DIFF
--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+  const content: any;
+  export default content;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "noEmit": false,
-    "jsx": "react"
+    "jsx": "react",
+    "noImplicitAny": false
   },
   "include": ["src"],
   "exclude": ["build", "node_modules"]


### PR DESCRIPTION
This change supresses the 'noImplicitAny' Typescript error and defines a module for SVG files.

It's intended to partially fix #13.

A better fix would be to go through all the 'any' type errors and supply types for them, but I didn't have the time.

Even after the change, there are a dozen or so issues reported in the code.